### PR TITLE
add support for labels

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -42,12 +42,12 @@
   revision = "130e6b02ab059e7b717a096f397c5b60111cae74"
 
 [[projects]]
-  branch = "master"
-  digest = "1:e9d85290d89e83245e1410cb3ed32b39c70ca7aa80ec3b1e92bf0a0eab859426"
+  digest = "1:b453d4e75b817dda55b21af53a750bc15b7fece8ecfc77cd6a279cdc94223b09"
   name = "github.com/google/go-github"
   packages = ["github"]
   pruneopts = ""
-  revision = "922ceac0585d40f97d283d921f872fc50480e06e"
+  revision = "e881974953e6ab6d1a6a1610e98ed6401a3aa1ba"
+  version = "v32.1.0"
 
 [[projects]]
   branch = "master"
@@ -150,6 +150,22 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:678eb8275bb8e3394737d136f55da106956c699fb4ccc3e72aa115123cd28d0d"
+  name = "golang.org/x/crypto"
+  packages = [
+    "cast5",
+    "openpgp",
+    "openpgp/armor",
+    "openpgp/elgamal",
+    "openpgp/errors",
+    "openpgp/packet",
+    "openpgp/s2k",
+  ]
+  pruneopts = ""
+  revision = "5c72a883971a4325f8c62bf07b6d38c20ea47a6a"
+
+[[projects]]
+  branch = "master"
   digest = "1:6566ccb4bc1f6ba66b8c478057c514f51de857230b71c8b333b0d6d4983aea69"
   name = "golang.org/x/net"
   packages = [
@@ -214,32 +230,16 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/cpuguy83/go-md2man/md2man",
-    "github.com/davecgh/go-spew/spew",
     "github.com/facebookgo/errgroup",
     "github.com/fatih/color",
-    "github.com/golang/protobuf/proto",
     "github.com/google/go-github/github",
-    "github.com/google/go-querystring/query",
-    "github.com/inconshreveable/mousetrap",
-    "github.com/juju/errors",
-    "github.com/mattn/go-colorable",
-    "github.com/mattn/go-isatty",
     "github.com/nathanleiby/diffparser",
-    "github.com/pmezard/go-difflib/difflib",
-    "github.com/russross/blackfriday",
     "github.com/spf13/cobra",
     "github.com/spf13/cobra/doc",
-    "github.com/spf13/pflag",
     "github.com/stretchr/testify/assert",
     "github.com/xanzy/go-gitlab",
-    "golang.org/x/net/context",
-    "golang.org/x/net/context/ctxhttp",
     "golang.org/x/oauth2",
     "golang.org/x/sync/semaphore",
-    "golang.org/x/sys/unix",
-    "google.golang.org/appengine/urlfetch",
-    "gopkg.in/yaml.v2",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -19,12 +19,14 @@ import (
 var pushFlagAssignee string
 var pushFlagThrottle string
 var pushFlagBodyFile string
+var pushFlagLabels []string
 
 // rate limits the # of git pushes. used to prevent load on CI system
 var pushThrottle *time.Ticker
 
 var prAssignee string
 var prBody string
+var prLabels []string
 
 var pushCmd = &cobra.Command{
 	Use:   "push",
@@ -63,6 +65,14 @@ var pushCmd = &cobra.Command{
 				log.Fatalf("Error parsing --throttle flag: %s", err.Error())
 			}
 			pushThrottle = time.NewTicker(dur)
+		}
+
+		labels, err := cmd.Flags().GetStringSlice("labels")
+		if err != nil {
+			log.Fatal(err)
+		}
+		if len(labels) > 0 {
+			prLabels = labels
 		}
 
 		repos, err := whichRepos(cmd)
@@ -120,6 +130,7 @@ func pushOneRepo(r initialize.Repo, ctx context.Context) error {
 		PRAssignee:    prAssignee,
 		BranchName:    planOutput.BranchName,
 		RepoOwner:     r.Owner,
+		Labels:        prLabels,
 	}
 	var output push.Output
 	var err error

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,7 @@ func init() {
 	pushCmd.Flags().StringVarP(&pushFlagThrottle, "throttle", "t", "30s", "Throttle number of pushes, e.g. '30s' means 1 push per 30 seconds")
 	pushCmd.Flags().StringVarP(&pushFlagAssignee, "assignee", "a", "", "Github user to assign the PR to")
 	pushCmd.Flags().StringVarP(&pushFlagBodyFile, "body-file", "b", "", "body of PR")
+	pushCmd.Flags().StringSliceVarP(&pushFlagLabels, "labels", "l", nil, "labels to attach to PR")
 
 	rootCmd.AddCommand(statusCmd)
 

--- a/initialize/initialize.go
+++ b/initialize/initialize.go
@@ -205,7 +205,7 @@ func githubRepoSearch(query string) ([]Repo, error) {
 
 		for _, repoResult := range result.Repositories {
 			numProcessedResults = numProcessedResults + 1
-			allRepos[*repoResult.Name] = &repoResult
+			allRepos[*repoResult.Name] = repoResult
 		}
 
 		incompleteResults := result.GetIncompleteResults()

--- a/push/push.go
+++ b/push/push.go
@@ -41,6 +41,8 @@ type Input struct {
 	RepoOwner string
 	// BranchName is the branch name in Git
 	BranchName string
+	// Labels
+	Labels []string
 }
 
 // Output from Push()
@@ -132,6 +134,18 @@ func GithubPush(ctx context.Context, input Input, repoLimiter *time.Ticker, push
 			return Output{Success: false}, err
 		}
 	}
+
+	if pr.Labels == nil || len(input.Labels) > 0 {
+		<-repoLimiter.C
+		// TODO: Compare current labels
+		_, _, err := client.Issues.AddLabelsToIssue(ctx, input.RepoOwner, input.RepoName, *pr.Number, input.Labels)
+		if err != nil {
+			return Output{Success: false}, err
+		}
+	}
+
+
+
 
 	<-repoLimiter.C
 	cs, _, err := client.Repositories.GetCombinedStatus(ctx, input.RepoOwner, input.RepoName, *pr.Head.SHA, nil)


### PR DESCRIPTION
This adds the ability to specify labels on opened PRs.

The current implementation will only check if there are no labels and if
there are not, add them. Further enhancements should loop through all
the labels and check the specified labels match the existing ones

## Testing

## Rollout